### PR TITLE
Length of fullname field of BinaryResource reduced to 722

### DIFF
--- a/eplmp-core/src/main/java/org/polarsys/eplmp/core/common/BinaryResource.java
+++ b/eplmp-core/src/main/java/org/polarsys/eplmp/core/common/BinaryResource.java
@@ -40,7 +40,7 @@ import java.util.Date;
 @Entity
 public class BinaryResource implements Serializable, Comparable<BinaryResource>{
 
-    @Column(length=1024)
+    @Column(length=722)
     @Id
     protected String fullName="";
 


### PR DESCRIPTION
Signed-off-by: Yacine Merghoub <yacine.merghoub@docdoku.com>

The size of the BinaryResource fullname field has been reduced to 722 to meet the limit of 3072 bytes for an index in a utf8 database of mysql.