### PR TITLE
percent issue when searching

### DIFF
--- a/eplmp-server/eplmp-server-ejb/src/main/java/org/polarsys/eplmp/server/DocumentManagerBean.java
+++ b/eplmp-server/eplmp-server-ejb/src/main/java/org/polarsys/eplmp/server/DocumentManagerBean.java
@@ -509,6 +509,10 @@ public class DocumentManagerBean implements IDocumentManagerLocal {
     @Override
     public DocumentRevision[] searchDocumentRevisions(DocumentSearchQuery pQuery, int from, int size) throws WorkspaceNotFoundException, UserNotFoundException, UserNotActiveException, WorkspaceNotEnabledException, AccountNotFoundException, NotAllowedException {
         User user = userManager.checkWorkspaceReadAccess(pQuery.getWorkspaceId());
+        String docId = pQuery.getDocMId();
+        if(docId != null){
+            checkDocumentIdValidity(docId, new Locale(user.getLanguage()));
+        }
         List<DocumentRevision> fetchedDocRs = indexerManager.searchDocumentRevisions(pQuery, from, size);
         List<DocumentRevision> docList = new ArrayList<>();
 

--- a/eplmp-server/eplmp-server-rest/src/main/java/org/polarsys/eplmp/server/rest/util/SearchQueryParser.java
+++ b/eplmp-server/eplmp-server-rest/src/main/java/org/polarsys/eplmp/server/rest/util/SearchQueryParser.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
-  * Copyright (c) 2017 DocDoku.
-  * All rights reserved. This program and the accompanying materials
-  * are made available under the terms of the Eclipse Public License v1.0
-  * which accompanies this distribution, and is available at
-  * http://www.eclipse.org/legal/epl-v10.html
-  *
-  * Contributors:
-  *    DocDoku - initial API and implementation
-  *******************************************************************************/
+ * Copyright (c) 2017 DocDoku.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    DocDoku - initial API and implementation
+ *******************************************************************************/
 
 package org.polarsys.eplmp.server.rest.util;
 
@@ -61,7 +61,8 @@ public class SearchQueryParser {
             if (values.size() == 1) {
                 String value = null;
                 try {
-                    value = URLDecoder.decode(values.get(0), "UTF-8");
+                    value = processPercent(values.get(0));
+                    value = URLDecoder.decode(value, "UTF-8");
                 } catch (UnsupportedEncodingException e) {
                     LOGGER.log(Level.FINEST, null, e);
                 }
@@ -169,7 +170,8 @@ public class SearchQueryParser {
             if (values.size() == 1) {
                 String value = null;
                 try {
-                    value = URLDecoder.decode(values.get(0), "UTF-8");
+                    value = processPercent(values.get(0));
+                    value = URLDecoder.decode(value, "UTF-8");
                 } catch (UnsupportedEncodingException e) {
                     LOGGER.log(Level.FINEST, null, e);
                 }
@@ -308,6 +310,14 @@ public class SearchQueryParser {
 
         }
         return pAttributes;
+    }
+
+    private static String processPercent(String input) {
+
+        String output = input;
+        output = output.replaceAll("%(?![0-9a-fA-F]{2})", "%25");
+        output = output.replaceAll("\\+", "%2B");
+        return output;
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Yacine Merghoub <yacine.merghoub@docdoku.com>

[Advanced search] Query with % usage failure :
Replace any % sign that is not a part of an encoded character with the percent encoded value (%25) and replaces the + sign with its encoded value (%2B).
Also, use of % sign within id search is forbidden since this character is forbidden when creating a document or a part.