### PR TITLE
Query String in search request is wrapped in json object urlencoded

### DIFF
--- a/eplmp-server/eplmp-server-ejb/src/main/resources/org/polarsys/eplmp/server/indexer/source-mapping.json
+++ b/eplmp-server/eplmp-server-ejb/src/main/resources/org/polarsys/eplmp/server/indexer/source-mapping.json
@@ -18,9 +18,19 @@
         "default_string": {
           "match": "*",
           "match_mapping_type": "string",
+          "unmatch": "attr_*",
           "mapping": {
             "type": "string",
             "analyzer": "analyzer_case_insensitive"
+          }
+        }
+      },
+      {
+        "attributes": {
+          "match": "attr_*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
           }
         }
       }

--- a/eplmp-server/eplmp-server-rest/src/main/java/org/polarsys/eplmp/server/rest/DocumentsResource.java
+++ b/eplmp-server/eplmp-server-rest/src/main/java/org/polarsys/eplmp/server/rest/DocumentsResource.java
@@ -11,6 +11,9 @@
 
 package org.polarsys.eplmp.server.rest;
 
+import io.swagger.annotations.*;
+import org.dozer.DozerBeanMapperSingletonWrapper;
+import org.dozer.Mapper;
 import org.polarsys.eplmp.core.document.DocumentRevision;
 import org.polarsys.eplmp.core.exceptions.*;
 import org.polarsys.eplmp.core.exceptions.NotAllowedException;
@@ -21,9 +24,6 @@ import org.polarsys.eplmp.core.services.IDocumentWorkflowManagerLocal;
 import org.polarsys.eplmp.server.rest.dto.CountDTO;
 import org.polarsys.eplmp.server.rest.dto.DocumentRevisionDTO;
 import org.polarsys.eplmp.server.rest.util.SearchQueryParser;
-import io.swagger.annotations.*;
-import org.dozer.DozerBeanMapperSingletonWrapper;
-import org.dozer.Mapper;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.security.DeclareRoles;
@@ -126,6 +126,7 @@ public class DocumentsResource {
         size = size == 0 ? 10 : size;
 
         MultivaluedMap<String, String> params = uri.getQueryParameters();
+        // params is a multivalued Map which keys are json object base64 urlencoded
         DocumentSearchQuery documentSearchQuery = SearchQueryParser.parseDocumentStringQuery(workspaceId, params);
         DocumentRevision[] docRs = documentService.searchDocumentRevisions(documentSearchQuery, from, size);
         return mapToDTOs(docRs);

--- a/eplmp-server/eplmp-server-rest/src/main/java/org/polarsys/eplmp/server/rest/PartsResource.java
+++ b/eplmp-server/eplmp-server-rest/src/main/java/org/polarsys/eplmp/server/rest/PartsResource.java
@@ -11,6 +11,9 @@
 
 package org.polarsys.eplmp.server.rest;
 
+import io.swagger.annotations.*;
+import org.dozer.DozerBeanMapperSingletonWrapper;
+import org.dozer.Mapper;
 import org.polarsys.eplmp.core.change.ModificationNotification;
 import org.polarsys.eplmp.core.common.User;
 import org.polarsys.eplmp.core.configuration.ProductStructureFilter;
@@ -31,9 +34,6 @@ import org.polarsys.eplmp.server.rest.collections.QueryResult;
 import org.polarsys.eplmp.server.rest.dto.*;
 import org.polarsys.eplmp.server.rest.file.util.BinaryResourceUpload;
 import org.polarsys.eplmp.server.rest.util.SearchQueryParser;
-import io.swagger.annotations.*;
-import org.dozer.DozerBeanMapperSingletonWrapper;
-import org.dozer.Mapper;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.security.DeclareRoles;
@@ -210,6 +210,7 @@ public class PartsResource {
             @ApiParam(required = false, value = "Search mode (false for history / true for head only)") @QueryParam("fetchHeadOnly") boolean fetchHeadOnly)
             throws EntityNotFoundException, UserNotActiveException, AccessRightException, NotAllowedException {
 
+        // uri.getQueryParameters() is a multivalued Map which keys are json object base64 urlencoded
         PartSearchQuery partSearchQuery = SearchQueryParser.parsePartStringQuery(workspaceId, uri.getQueryParameters());
 
         // Set default size


### PR DESCRIPTION
Query String in search request is wrapped in json object urlencoded in Base64. So to be decoded before parsing. 
Correlated with PR https://github.com/docdoku/docdoku-web-front/pull/53

Signed-off-by: Yacine Merghoub <yacine.merghoub@docdoku.com>