### PR TITLE
avoid race condition with payara 4.181

### DIFF
--- a/eplmp-server/eplmp-server-ext/src/main/java/org/polarsys/eplmp/server/BeanLocator.java
+++ b/eplmp-server/eplmp-server-ext/src/main/java/org/polarsys/eplmp/server/BeanLocator.java
@@ -63,7 +63,7 @@ public class BeanLocator {
      */
     @SuppressWarnings("unchecked")
     // Cause : Generic Type Erasure
-    <T> List<T> search(Class<T> type, Context ctx) {
+    synchronized <T> List<T> search(Class<T> type, Context ctx) {
         List<T> result = new ArrayList<T>();
         try {
             NamingEnumeration<NameClassPair> ncps = ctx.list("");


### PR DESCRIPTION
When i tried to convert a STEP file with the PLM i Noticed than when two thread tried to load same bean an exception is raised.  This appear because i've corrected the error raised by openDecimater at the end of conversion which had the following message : 
```
[#|2019-04-12T09:07:38.429+0000|SEVERE|Payara 4.1|org.polarsys.eplmp.server.ConverterBean|_ThreadID=156;_ThreadName=__ejb-thread-pool14;_TimeMillis=1555060058429;_LevelValue=1000;|
 Decimation failed with code = 134 terminate called after throwing an instance of 'std::system_error'
 what():  Enable multithreading to use std::thread: Operation not permitted
|#]
```
So after corrected this on Opendecimater project the following exception raised : 

```
[#|2019-04-12T16:15:22.633+0000|SEVERE|Payara 4.1|javax.enterprise.ejb.container|_ThreadID=137;_ThreadName=__ejb-thread-pool2;_TimeMillis=1555085722633;_LevelValue=1000;|

  ejb.stateless_ejbcreate_exception|#]



[#|2019-04-12T16:15:22.635+0000|WARNING|Payara 4.1|javax.enterprise.ejb.container|_ThreadID=137;_ThreadName=__ejb-thread-pool2;_TimeMillis=1555085722635;_LevelValue=900;_MessageID=AS-EJB-00056;|

  A system exception occurred during an invocation on EJB ConverterBean, method: public void org.polarsys.eplmp.server.ConverterBean.convertCADFileToOBJ(org.polarsys.eplmp.core.product.PartIterationKey,org.polarsys.eplmp.core.common.BinaryResource)|#]



[#|2019-04-12T16:15:22.636+0000|WARNING|Payara 4.1|javax.enterprise.ejb.container|_ThreadID=137;_ThreadName=__ejb-thread-pool2;_TimeMillis=1555085722636;_LevelValue=900;|

  javax.ejb.EJBException: javax.ejb.EJBException: javax.ejb.CreateException: Could not create stateless EJB

	at com.sun.ejb.containers.StatelessSessionContainer._getContext(StatelessSessionContainer.java:446)

	at com.sun.ejb.containers.BaseContainer.getContext(BaseContainer.java:2596)

	at com.sun.ejb.containers.BaseContainer.preInvoke(BaseContainer.java:1987)

	at com.sun.ejb.containers.EjbAsyncTask.call(EjbAsyncTask.java:99)

	at java.util.concurrent.FutureTask.run(FutureTask.java:266)

	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)

	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)

	at java.lang.Thread.run(Thread.java:748)

Caused by: javax.ejb.EJBException: javax.ejb.CreateException: Could not create stateless EJB

	at com.sun.ejb.containers.StatelessSessionContainer$SessionContextFactory.create(StatelessSessionContainer.java:715)

	at com.sun.ejb.containers.util.pool.NonBlockingPool.getObject(NonBlockingPool.java:220)

	at com.sun.ejb.containers.StatelessSessionContainer._getContext(StatelessSessionContainer.java:442)

	... 7 more

Caused by: javax.ejb.CreateException: Could not create stateless EJB

	at com.sun.ejb.containers.StatelessSessionContainer.createStatelessEJB(StatelessSessionContainer.java:525)

	at com.sun.ejb.containers.StatelessSessionContainer.access$000(StatelessSessionContainer.java:99)

	at com.sun.ejb.containers.StatelessSessionContainer$SessionContextFactory.create(StatelessSessionContainer.java:713)

	... 9 more

Caused by: java.lang.Exception: java.lang.LinkageError: loader (instance of  org/glassfish/javaee/full/deployment/EarClassLoader): attempted  duplicate class definition for name: "com/sun/ejb/codegen/GenericEJBHome_Generated"

	at com.sun.ejb.containers.interceptors.CallbackInvocationContext.proceed(CallbackInvocationContext.java:209)

	at org.jboss.weld.ejb.AbstractEJBRequestScopeActivationInterceptor.aroundInvoke(AbstractEJBRequestScopeActivationInterceptor.java:73)

	at org.jboss.weld.ejb.SessionBeanInterceptor.aroundInvoke(SessionBeanInterceptor.java:52)

	at sun.reflect.GeneratedMethodAccessor166.invoke(Unknown Source)

	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

	at java.lang.reflect.Method.invoke(Method.java:498)

	at com.sun.ejb.containers.interceptors.CallbackInterceptor.intercept(InterceptorManager.java:998)

	at com.sun.ejb.containers.interceptors.CallbackChainImpl.invokeNext(CallbackChainImpl.java:72)

	at com.sun.ejb.containers.interceptors.CallbackInvocationContext.proceed(CallbackInvocationContext.java:205)

	at com.sun.ejb.containers.interceptors.SystemInterceptorProxy.doCall(SystemInterceptorProxy.java:163)

	at com.sun.ejb.containers.interceptors.SystemInterceptorProxy.init(SystemInterceptorProxy.java:125)

	at sun.reflect.GeneratedMethodAccessor225.invoke(Unknown Source)

	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

	at java.lang.reflect.Method.invoke(Method.java:498)

	at com.sun.ejb.containers.interceptors.CallbackInterceptor.intercept(InterceptorManager.java:998)

	at com.sun.ejb.containers.interceptors.CallbackChainImpl.invokeNext(CallbackChainImpl.java:72)

	at com.sun.ejb.containers.interceptors.InterceptorManager.intercept(InterceptorManager.java:417)

	at com.sun.ejb.containers.interceptors.InterceptorManager.intercept(InterceptorManager.java:380)

	at com.sun.ejb.containers.BaseContainer.intercept(BaseContainer.java:2030)

	at com.sun.ejb.containers.StatelessSessionContainer.createStatelessEJB(StatelessSessionContainer.java:518)

	... 11 more

Caused by: java.lang.LinkageError: loader (instance of  org/glassfish/javaee/full/deployment/EarClassLoader): attempted  duplicate class definition for name: "com/sun/ejb/codegen/GenericEJBHome_Generated"

	at sun.misc.Unsafe.defineClass(Native Method)

	at org.glassfish.pfl.basic.reflection.BridgeBase.defineClass(BridgeBase.java:227)

	at org.glassfish.pfl.dynamic.codegen.impl.CodeGeneratorUtil.makeClass(CodeGeneratorUtil.java:70)

	at org.glassfish.pfl.dynamic.codegen.spi.Wrapper._generate(Wrapper.java:1083)

	at org.glassfish.pfl.dynamic.codegen.spi.Wrapper._generate(Wrapper.java:1067)

	at com.sun.ejb.EJBUtils.generateAndLoad(EJBUtils.java:599)

	at com.sun.ejb.EJBUtils.loadGeneratedGenericEJBHomeClass(EJBUtils.java:551)

	at com.sun.ejb.EJBUtils.lookupRemote30BusinessObject(EJBUtils.java:409)

	at com.sun.ejb.containers.RemoteBusinessObjectFactory.getObjectInstance(RemoteBusinessObjectFactory.java:75)

	at javax.naming.spi.NamingManager.getObjectInstance(NamingManager.java:321)

	at com.sun.enterprise.naming.impl.SerialContext.getObjectInstance(SerialContext.java:532)

	at com.sun.enterprise.naming.impl.SerialContext.lookup(SerialContext.java:492)

	at com.sun.enterprise.naming.impl.SerialContext.lookup(SerialContext.java:442)

	at org.polarsys.eplmp.server.BeanLocator.search(BeanLocator.java:73)

	at org.polarsys.eplmp.server.BeanLocator.search(BeanLocator.java:80)

	at org.polarsys.eplmp.server.BeanLocator.search(BeanLocator.java:80)

	at org.polarsys.eplmp.server.BeanLocator.search(BeanLocator.java:45)

	at org.polarsys.eplmp.server.ConverterBean.init(ConverterBean.java:88)

	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)

	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

	at java.lang.reflect.Method.invoke(Method.java:498)

	at com.sun.ejb.containers.interceptors.BeanCallbackInterceptor.intercept(InterceptorManager.java:1047)

	at com.sun.ejb.containers.interceptors.CallbackChainImpl.invokeNext(CallbackChainImpl.java:72)

	at com.sun.ejb.containers.interceptors.CallbackInvocationContext.proceed(CallbackInvocationContext.java:205)

	... 30 more

|#]



[#|2019-04-12T16:15:22.744+0000|INFO|Payara 4.1|org.polarsys.eplmp.server.BeanLocator|_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085722744;_LevelValue=800;|

  EJB found: DaeFileConverterImpl!org.polarsys.eplmp.server.converters.CADConverter|#]



[#|2019-04-12T16:15:22.803+0000|INFO|Payara 4.1|org.polarsys.eplmp.server.BeanLocator|_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085722803;_LevelValue=800;|

  EJB found: CatiaFileParserImpl!org.polarsys.eplmp.server.converters.CADConverter|#]



[#|2019-04-12T16:15:22.913+0000|INFO|Payara 4.1|org.polarsys.eplmp.server.BeanLocator|_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085722913;_LevelValue=800;|

  EJB found: ObjFileConverterImpl!org.polarsys.eplmp.server.converters.CADConverter|#]



[#|2019-04-12T16:15:22.921+0000|INFO|Payara 4.1|org.polarsys.eplmp.server.BeanLocator|_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085722921;_LevelValue=800;|

  EJB found: SolidworksFileParserImpl!org.polarsys.eplmp.server.converters.CADConverter|#]



[#|2019-04-12T16:15:22.925+0000|INFO|Payara 4.1|org.polarsys.eplmp.server.BeanLocator|_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085722925;_LevelValue=800;|

  EJB found: StepFileConverterImpl!org.polarsys.eplmp.server.converters.CADConverter|#]



[#|2019-04-12T16:15:22.938+0000|INFO|Payara 4.1|org.polarsys.eplmp.server.BeanLocator|_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085722938;_LevelValue=800;|

  EJB found: IFCFileConverterImpl!org.polarsys.eplmp.server.converters.CADConverter|#]



[#|2019-04-12T16:15:22.940+0000|INFO|Payara 4.1|org.glassfish.kernel.javaee.MEJBService|_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085722940;_LevelValue=800;|

  Loading MEJB app on JNDI look up|#]



[#|2019-04-12T16:15:23.172+0000|INFO|Payara 4.1|javax.enterprise.ejb.container|_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085723172;_LevelValue=800;_MessageID=AS-EJB-00054;|

  Portable JNDI names for EJB MEJBBean: [java:global/mejb/MEJBBean, java:global/mejb/MEJBBean!javax.management.j2ee.ManagementHome]|#]



[#|2019-04-12T16:15:23.173+0000|INFO|Payara 4.1|javax.enterprise.ejb.container|_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085723173;_LevelValue=800;_MessageID=AS-EJB-00055;|

  Glassfish-specific (Non-portable) JNDI names for EJB MEJBBean: [ejb/mgmt/MEJB]|#]



[#|2019-04-12T16:15:23.181+0000|INFO|Payara 4.1||_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085723181;_LevelValue=800;|

  Cannot find the resource bundle for the name com.sun.logging.enterprise.system.tools.deployment for class org.glassfish.ejb.deployment.BeanMethodCalculatorImpl using org.glassfish.main.ejb.ejb-container [5]|#]



[#|2019-04-12T16:15:23.233+0000|INFO|Payara 4.1|org.polarsys.eplmp.server.BeanLocator|_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085723233;_LevelValue=800;|

  Ignoring JNDI entry: Lookup failed for 'java:global/mejb/MEJBBean' in SerialContext[myEnv={java.naming.factory.initial=com.sun.enterprise.naming.impl.SerialInitContextFactory, java.naming.factory.state=com.sun.corba.ee.impl.presentation.rmi.JNDIStateFactoryImpl, java.naming.factory.url.pkgs=com.sun.enterprise.naming}|#]



[#|2019-04-12T16:15:23.235+0000|INFO|Payara 4.1|org.polarsys.eplmp.server.BeanLocator|_ThreadID=138;_ThreadName=__ejb-thread-pool3;_TimeMillis=1555085723235;_LevelValue=800;|

  Ignoring JNDI entry: Lookup failed for 'java:global/mejb/MEJBBean!org.glassfish.admin.mejb.MEJBHome' in SerialContext[myEnv={java.naming.factory.initial=com.sun.enterprise.naming.impl.SerialInitContextFactory, java.naming.factory.state=com.sun.corba.ee.impl.presentation.rmi.JNDIStateFactoryImpl, java.naming.factory.url.pkgs=com.sun.enterprise.naming}|#]
```

This PR avoid to raise exception when two thread try to load same bean. Payara has already make a patch to fix this [troubles]( https://github.com/payara/Payara/issues/2763 ) but unfortunately this version is not compatible with the PLM project for now.
